### PR TITLE
V0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: vdsql-testing
+on:
+  pull_request:
+    branches:
+      - stable
+      - develop
+  push:
+    branches:
+      - stable
+      - develop
+
+jobs:
+  run-tests:
+
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, "3.10"]
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.pythonversion }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install vdsql
+      run: pip3 install .
+
+    - name: Ensure it starts up
+      run: vdsql --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # vdsql version history
 
+# 0.2 (2022-08-31)
+
+- fix support for bigquery (thanks @cpcloud for PR #6)
+- add clickhouse support
+  - add clickhouse dependency installs
+- update support for mysql and postgres
+- register duckdb with `.ddb` extension
+- register sqlite with `.sqlite3` extension
+
+- disable commands unimplemented in vdsql
+- add `addcol-expr` (keybinding `=`)
+- `zv` to choose sidebar style
+- `v` to toggle instead of cycle
+- `gv` to open sidebar contents in new sheet
+- add `adcol-cast` (keybinding: `'`) to cast column
+- add `exec-sql` command
+- implement `split-col` by delimiter
+- implement `addcol-subst`
+- add `dup-limit` (keybinding `z"`) and `dup-nolimit` (keybinding `gz"`)
+
+- add **Frequency Table** support for derived columns (e.g. **Expression Columns**)
+- add `options.sql_always_count` (default: False), which determines whether to always query
+  a count of the number of results
+- add `ibis_type` to **Columns Sheet**
+- add title of current sidebar contents
+- add aggregation aliases to ibis
+- add histogram percent and histogram columns
+  - histogram is gated on `options.disp_histo*`
+  - histogram is disabled by default
+- on dup and freeze-col, cast columns if type is different
+- set `options.clean_names` to `True` for all ibis sheets
+- [sidebar] do not error if no column expression
+- open `PyobjSheet` if not **Frequency Table**
+- [join] add suffix for same-named columns from right side
+- do not include index names in subtables
+
+## Bugfixes
+
+- filters working with `z|`
+- fixes to
+  - types
+  - aggregates
+  - `unselect-rows`
+  - outer/full join
+  - bq:// scheme
+  - `stoggle-rows`
+  - `dup-sheet`
+- workaround relational integrity issue
+- use correct ibis col for groupby
+- `stoggle` when none selected should select all
+- scoop null use `isnull()`
+- [expand] do not drop original struct
+
+## Performance
+
+- add connection pool for concurrent loads
+- performance improvements in querying and query counting
+
+## API
+
+- `ibis_filters` is now `ibis_selection`
+- `ibis_future_expr` is now `pendir_expr`
+
+
 # 0.1.1 (2022-08-08)
 
 - limit install of ibis-framework dependencies to sqlite and duckdb

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ This will install both:
 
     pip install git+https://github.com/visidata/vdsql.git
 
-    echo "import vdsql" >> ~/.visidatarc
-
-
 ### Install Ibis backends
 
 To minimize dependencies, only the sqlite backend is included by default.


### PR DESCRIPTION
- [ ] Test that Frequency Table works on Sqlite with newest Ibis
- [x] VisiData 2.10.1 and Ibis 3.2.0
- [ ] Ensure new commands and options are included in the README
- [ ] Include only the `ibis-framework[sqlite]` and provide instructions for downloading dependencies for other backends. Test if a package is present, and if not issue `vd.fail("pip install ibis-framework[foo] to support foo")`?
- [ ] Update CHANGELOG
- [ ] Update vdsql version