### PR TITLE
Fix issue #16, reverting to version before commit c217ca9

### DIFF
--- a/vdsql/_ibis.py
+++ b/vdsql/_ibis.py
@@ -125,7 +125,7 @@ class IbisTableIndexSheet(IndexSheet):
             nrows_col.width += 3
 
             for tblname in con.list_tables():
-                yield self.sheet_type(tblname,
+                yield IbisTableSheet(tblname,
                         ibis_source=self.source,
                         ibis_filetype=self.filetype,
                         ibis_conpool=self.ibis_conpool,


### PR DESCRIPTION
Commit c217ca9 change call from `IbisTableSheet()` to `self.sheet_index()`.

`self.sheet_index()` can not be found in the code.

Reverting back to yielding `IbisTableSheet()` removes the error and vdsql is then usable with BigQuery.